### PR TITLE
GDPR personal data processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The rough print and the fine print. We try to make all our policies as clear, fa
 
 * [Terms of Service](terms/index.md)
 * [Privacy policy](privacy/index.md)
+* [General Data Protection Regulation (GDPR)](privacy/gdpr/index.md)
 * [EU-US and Swiss-US Privacy Shield policy](privacy-shield/index.md)
 * [Refund policy](refund/index.md)
 * [Copyright policy](copyright/index.md)

--- a/privacy/gdpr/index.md
+++ b/privacy/gdpr/index.md
@@ -1,0 +1,25 @@
+---
+title: Basecamp GDPR compliance
+
+layout: sheet
+---
+
+# Basecamp GDPR compliance
+
+The EU [General Data Protection Regulation](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) (GDPR) comes into effect on May 25, 2018. Basecamp is ready.
+
+## Does GDPR affect me?
+
+If you're based in the EU or do business in the EU, yeah! GDPR has a long reach. If you have [any EU personal data in your Basecamp account](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/), such as names, email addresses, ID numbers, or… anything personally identifiable, then GDPR applies. You are a Controller of personal data under GDPR, so you need to enter into GDPR-compliant data processing agreements with any online services and third party vendors you rely on, including Basecamp. These agreements are commonly called a Data Processing Addendum, or DPA.
+
+## Data Processing Addendum
+
+Contracts required! Processing EU personal data must be governed by a [GDPR-compliant contract](https://gdpr-info.eu/art-28-gdpr/). We provide a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) (DPA) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
+
+**✍️ [Sign the DPA online here](https://app.hellosign.com/s/c0908a3d).**
+
+Basecamp participates in the [EU-US and Swiss-US Privacy Shield Framework](/about/policies/privacy/privacy-shield) to safeguard the transfer of personal data to the US, meeting the GDPR requirement for adequate data protection laws.
+
+## Subprocessors
+
+Basecamp uses third party subprocessors, such as cloud computing providers and customer support software, to provide our services. We enter into GDPR-compliant data processing agreements with each subprocessor, and require the same of them. [List of Basecamp subprocessors](/about/policies/privacy/subprocessors).

--- a/privacy/subprocessors/index.md
+++ b/privacy/subprocessors/index.md
@@ -1,0 +1,20 @@
+---
+title: Basecamp subprocessors
+
+layout: sheet
+---
+
+# Basecamp subprocessors
+
+Basecamp uses third party subprocessors, such as cloud computing providers and customer support software, to provide our services. We enter into GDPR-compliant data processing agreements with each subprocessor, extending [GDPR safeguards](/about/policies/privacy/gdpr) everywhere personal data is processed.
+
+Subprocessors located in the United States:
+* [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
+* [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
+* [Clicky](https://clicky.com/help/faq/privacy/gdpr). Web analytics service.
+* [Customer.io](https://customer.io/gdpr.html). Email newsletter service.
+* [Google Analytics](https://support.google.com/analytics/answer/6004245?hl=en). Web analytics service.
+* [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
+* [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
+* [Sentry](https://blog.sentry.io/2018/03/14/gdpr-sentry-and-you). Error reporting software.
+* [Twilio](https://www.twilio.com/gdpr). Text messaging service.


### PR DESCRIPTION
* Link to sign the Data Processing Addendum (DPA) governing processing of EU personal data in Basecamp accounts. Satisfies the GDPR requirement that controllers (Basecamp's customers) have a written contract with their processors (Basecamp and other services).
* A full listing of our [Subprocessors](https://basecamp.com/about/policies/privacy/subprocessors).