### PR TITLE
List security researchers rather than pulling from Jekyll data

### DIFF
--- a/security/vulnerability-response.md
+++ b/security/vulnerability-response.md
@@ -25,12 +25,80 @@ Our products are built on the Ruby on Rails framework (which we created and main
 
 We respect the time and talent that drives new discoveries in web security technology. The following researchers and companies have gone out of their way to work with us to find, fix, and disclose security flaws safely:
 
-<ul>
-{% for person in site.data.security-responders %}
-  {% if person.url %}
-    <li><a href="{{ person.url }}" target="_blank" rel="noopener noreferrer">{{ person.name }}</a></li>
-  {% else %}
-    <li>{{ person.name }}</li>
-  {% endif %}
-{% endfor %}
-</ul>
+* Brett Hardin
+* Brian Mastenbrook
+* Clouds
+* Emanuel Bronshtein
+* Jeremy Mack
+* John Firebaugh
+* Kamil Sevi
+* Marko Karppinen
+* Matasano Security
+* MustLive
+* Nathan Kontny
+* nGenuity Information Services
+* ONZRA
+* Óscar Repáraz
+* Rakan Alotaibi @hxteam
+* Simon Brown
+* Tim Bach
+* Jan Habermann
+* John Menerick
+* Prajal Kulkarni
+* Ajay Singh Negi
+* Harsha Vardhan Boppana (Login Security Solution (P) Limited)
+* Frans Rosén
+* Rafay Baloch
+* M.R. Vignesh Kumar
+* Himanshu Kumar Das
+* Krutarth Shukla
+* Ahmad Ashraff
+* InverseKey
+* Adino Namchu
+* Atulkumar Hariba Shedage
+* West Arete
+* Abhinav Karnawat \/ w4rri0r \/
+* Mahadev subedi
+* Vedachala
+* Ehraz Ahmed
+* Umraz Ahmed
+* Ahsan Akhtar
+* Jose Pino
+* Priyal Viroja
+* Chris Raethke (Bugcrowd)
+* Siddhesh Gawde
+* Vinesh N. Redkar
+* Swapnil Thaware
+* Hammad Shamsi
+* Saurabh Chandrakant Nemade
+* Nitin Goplani
+* Sahil Saif
+* Rafael Pablos
+* Nutan Kumar Panda
+* Koutrouss Naddara
+* Gurjant Singh
+* Mayank Kapoor
+* FailHunters Crew
+* Daniel Alvear(MaztoR IN-Security)
+* Ali Hassan Ghori (@alihasanghauri)
+* Rodolfo Godalle Jr.
+* Simone Memoli
+* Daksh Patel
+* Jovan Šikanja
+* Muhammad Talha Khan
+* Yash Pandya
+* Mark Dodwell
+* Gabe Marshall
+* Matt Jaynes
+* Nakul Mohan (@Anonymous\_India)
+* Hardik Tailor
+* Marques Johansson
+* Rishiraj Sharma
+* Yogendra Sharma
+* Prashant Padmashali
+* Apoorv Joshi
+* Shivam Kumar Agarwal, Nithish Varghese, and Sahil Srivastava
+* Shahmeer Amir
+* Hamid Ashraf
+* Babar Khan Akhunzada
+* Ramin Farajpour Cami


### PR DESCRIPTION
Closes #8. No policy changes.