### PR TITLE
Prepare for the United Kingdom leaving the European Union

### DIFF
--- a/privacy/privacy-shield.md
+++ b/privacy/privacy-shield.md
@@ -1,10 +1,10 @@
 # Basecamp EU-US and Swiss-US Privacy Shield policy
 
-*Last updated: December 20, 2018*
+*Last updated: April 3, 2019*
 
 The privacy of your data—and it is your data, not ours!—is a big deal to us. We’ll only ever access your account to help you with a problem or squash a software bug. We’ll never open any uploaded files unless you ask us to. We log all access to all accounts by IP address, so we can always verify that no unauthorized access has happened for as long as the logs are kept.
 
-This policy applies to personal data from the European Union and from Switzerland that is collected, used, and retained by us in the United States.
+This policy applies to personal data from the European Union, the United Kingdom, and Switzerland which is collected, used, and retained by us in the United States.
 
 ## Identity & Access
 When you sign up for Basecamp, we ask for your name, company name, and email address. That's just so you can personalize your new account, and we can send you invoices, updates, or other essential information. We’ll never sell your personal info to third parties, and we won’t use your name or company in marketing statements without your permission, either.
@@ -19,7 +19,7 @@ When you write Basecamp with a question or to ask for help, we'll keep that corr
 
 The only times we’ll ever share your info:
 
-  * To provide products or services you've requested, with your permission.
+  * To provide products or services you've requested, with your permission. [List of third-party services we use](/privacy/subprocessors.md).
   * To investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of our [Terms of Service](/terms.md), or as otherwise required by law.
   * If Basecamp is acquired by or merged with another company—we don’t plan on that, but if it happens—we’ll notify you well before any info about you is transferred and becomes subject to a different privacy policy.
 
@@ -60,18 +60,18 @@ In order to improve our services and the website, and provide more convenient, r
 ## Third Parties
 You understand that Basecamp uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to provide you with our services. A current list of vendors is available upon request.
 
-In cases of onward transfer to these third parties for data of EU or Swiss individuals received pursuant to the Privacy Shield Frameworks, Basecamp is potentially liable should any issues or concerns arise.
+In cases of onward transfer to these third parties for data of EU, United Kingdom, or Swiss individuals received pursuant to the Privacy Shield Frameworks, Basecamp is potentially liable should any issues or concerns arise.
 
 ## Deleted Data
 When you cancel your account, we'll ensure that nothing is stored on our servers past 30 days. Anything you delete on your account while it's active will also be purged within 30 days (up until then it's available in the trash can).
 
 ## EU-US and Swiss-US Privacy Shield Framework
-Basecamp complies with the EU-U.S. Privacy Shield Framework and the Swiss-U.S. Privacy Shield Framework as set forth by the U.S. Department of Commerce regarding the collection, use, and retention of personal information transferred from the European Union and Switzerland to the United States, respectively. Basecamp has certified to the Department of Commerce that it adheres to the Privacy Shield Principles. If there is any conflict between the terms in this privacy policy and the Privacy Shield Principles, the Privacy Shield Principles shall govern. To learn more about the Privacy Shield program, and to view our certification, please visit <a href="https://www.privacyshield.gov/">https://www.privacyshield.gov/</a>.
+Basecamp complies with the EU-U.S. Privacy Shield Framework and the Swiss-U.S. Privacy Shield Framework as set forth by the U.S. Department of Commerce regarding the collection, use, and retention of personal information transferred from the European Union, the United Kingdom, and Switzerland to the United States, respectively. Basecamp has certified to the Department of Commerce that it adheres to the Privacy Shield Principles. If there is any conflict between the terms in this privacy policy and the Privacy Shield Principles, the Privacy Shield Principles shall govern. To learn more about the Privacy Shield program, and to view our certification, please visit <a href="https://www.privacyshield.gov/">https://www.privacyshield.gov/</a>.
 
 Basecamp is subject to the investigatory and enforcement powers of the Federal Trade Commission (FTC) with regard to the Privacy Shield Frameworks.
 
 ## EU-US and Swiss-US Privacy Complaints
-In compliance with the US-EU and Swiss-US Privacy Shield Principles, Basecamp commits to resolve complaints about your privacy and our collection or use of your personal information. European Union or Swiss individuals with inquiries or complaints regarding this privacy policy should first contact Jeremy Daer at Basecamp at [privacyshield@basecamp.com](mailto:privacyshield@basecamp.com), or by mail at Basecamp, LLC, 30 North Racine Avenue #200, Chicago, IL 60607 USA. 
+In compliance with the US-EU and Swiss-US Privacy Shield Principles, Basecamp commits to resolve complaints about your privacy and our collection or use of your personal information. European Union, United Kingdom, or Swiss individuals with inquiries or complaints regarding this privacy policy should first contact Jeremy Daer at Basecamp at [privacyshield@basecamp.com](mailto:privacyshield@basecamp.com), or by mail at Basecamp, LLC, 30 North Racine Avenue #200, Chicago, IL 60607 USA.
 
 Basecamp has further committed to refer unresolved privacy complaints under the EU-US and Swiss-US Privacy Shield Principles to an independent dispute resolution mechanism, the BBB EU PRIVACY SHIELD, operated by the Council of Better Business Bureaus. If you do not receive timely acknowledgment of your complaint, or if your complaint is not satisfactorily addressed, please visit <a href="http://www.bbb.org/EU-privacy-shield/for-eu-consumers">http://www.bbb.org/EU-privacy- shield/for-eu-consumers</a> for more information and to file a complaint.
 


### PR DESCRIPTION
Following the guidance [here](https://www.privacyshield.gov/article?id=Privacy-Shield-and-the-UK-FAQs), a few tweaks to extend our Privacy Shield commitment to the United Kingdom, in preparation for the UK leaving the European Union.

I also added a link to our sub-processors, for consistency with our main privacy policy page.