### PR TITLE
note possible charge if missing full billing addresses

### DIFF
--- a/taxes.md
+++ b/taxes.md
@@ -26,6 +26,8 @@ You'll see sales tax on your invoice if you live in:
 * Washington
 * West Virginia
 
+In order to collect sales tax correctly, we need your full billing address. If your account does not have a full billing address on record, we may apply an extra charge to your invoices based on the average sales tax rate of municipalities that also charge sales tax on transactions without known sales origins.
+
 If you need to change your billing information because you don't actually reside in a taxable state, you can easily handle that within [Basecamp 3](https://3.basecamp-help.com/article/101-handling-billing-and-invoices#update), [Basecamp 2](https://2.basecamp-help.com/article/241-billing-info-and-plan-upgrades#credit-card), and [Basecamp Classic](https://help.basecamp.com/basecamp/questions/148-how-do-we-update-or-change-our-credit-card). Please contact our Support team at [support@basecamp.com](mailto:support@basecamp.com) if you have trouble.
 
 Please also drop an email to [support@basecamp.com](mailto:support@basecamp.com) if:


### PR DESCRIPTION
Some municipalities require that we pay taxes on a proportion of any sales with unknown geographic origins. Since we aren't collecting taxes on any transactions without full billing addresses, we have been eating those costs. We've previously sent out an email to all existing active, paid customers who are missing full billing addresses on their credit cards and are sending out another set of reminders soon. For any customers who still have not shared a full billing address, we may start charging a small fee (based on the average tax rate of the municipalities that charge tax on sales with unknown geographic origins) for any sales missing full billing addresses.