### PR TITLE
Add cancellation policy and clarify corresponding Terms of Service language

### DIFF
--- a/cancellation.md
+++ b/cancellation.md
@@ -5,15 +5,15 @@
 We want satisfied customers, not hostages. That&rsquo;s why we make it easy for you to cancel your account directly in all of our apps — no phone calls required, no questions asked.
 
 Account owners can follow these instructions to cancel in-app:
-* [Basecamp 3][https://3.basecamp-help.com/article/156-cancel-your-basecamp-account]
-* [Basecamp 2][https://2.basecamp-help.com/article/243-canceling-and-pausing#cancel]
-* [Basecamp Classic][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Basecamp]
-* [Highrise][https://help.highrisehq.com/account/upgrade-downgrade-cancel-account/#cancel]
-* [Backpack][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Backpack]
-* [Campfire][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Campfire]
-* [37Suite][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Suite]
+* [Basecamp 3](https://3.basecamp-help.com/article/156-cancel-your-basecamp-account)
+* [Basecamp 2](https://2.basecamp-help.com/article/243-canceling-and-pausing#cancel)
+* [Basecamp Classic](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Basecamp)
+* [Highrise](https://help.highrisehq.com/account/upgrade-downgrade-cancel-account/#cancel)
+* [Backpack](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Backpack)
+* [Campfire](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Campfire)
+* [37Suite](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Suite)
 
-Our legal responsibility is to account owners, which means we cannot cancel an account at the request of anyone else. If for whatever reason you no longer know who the account owner is, [contact us][https://basecamp.com/support]. We will gladly reach out to any current account owners at the email addresses we have on file.
+Our legal responsibility is to account owners, which means we cannot cancel an account at the request of anyone else. If for whatever reason you no longer know who the account owner is, [contact us](https://basecamp.com/support). We will gladly reach out to any current account owners at the email addresses we have on file.
 
 ## What happens when you cancel?
 
@@ -21,7 +21,7 @@ You won&rsquo;t be able to access your account once you cancel, so make sure you
 
 We&rsquo;ll permanently delete your account data within 30 days from our servers and logs, and within 60 days from our backups. Retrieving data for a single account from a backup isn&rsquo;t possible, so if you change your mind you&rsquo;ll need to do it within the first 30 days. **Data can&rsquo;t be recovered once it has been permanently deleted.**
 
-We won&rsquo;t bill you again once you cancel. We don&rsquo;t automatically prorate any unused time you may have left but if you haven&rsquo;t used your account in months or just started a new billing cycle, [contact us][https://basecamp.com/support] for a [fair refund][https://basecamp.com/about/policies/refund]. We&rsquo;ll treat you right.
+We won&rsquo;t bill you again once you cancel. We don&rsquo;t automatically prorate any unused time you may have left but if you haven&rsquo;t used your account in months or just started a new billing cycle, [contact us](https://basecamp.com/support) for a [fair refund](https://basecamp.com/about/policies/refund). We&rsquo;ll treat you right.
 
 ## Basecamp-initiated cancellations
 
@@ -30,4 +30,4 @@ Basecamp may cancel accounts if they have been inactive for an extended period:
 * For frozen accounts: 180 days after being frozen due to billing failures
 * For free accounts: after 365 days of inactivity
 
-Basecamp also retains the right to suspend or terminate accounts for any reason at any time, as outlined in our [Terms of Service][https://basecamp.com/about/policies/terms]. In practice, this means we will cancel your account without notice if we have evidence that you are using our products to engage in illegal behavior.
+Basecamp also retains the right to suspend or terminate accounts for any reason at any time, as outlined in our [Terms of Service](https://basecamp.com/about/policies/terms). In practice, this means we will cancel your account without notice if we have evidence that you are using our products to engage in illegal behavior.

--- a/cancellation.md
+++ b/cancellation.md
@@ -1,0 +1,29 @@
+# Cancellation policy
+
+*Last updated: September 16, 2019*
+
+We hope that you love your Basecamp product but if you decide you no longer need it, we believe it should be easy for you to cancel your subscription. That&rsquo;s why we&rsquo;ve made it easy for you to cancel directly via each application, no questions asked.
+
+Account owners can follow these instructions to cancel in-app:
+* [Basecamp 3][https://3.basecamp-help.com/article/156-cancel-your-basecamp-account]
+* [Basecamp 2][https://2.basecamp-help.com/article/243-canceling-and-pausing#cancel]
+* [Basecamp Classic][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Basecamp]
+* [Highrise][https://help.highrisehq.com/account/upgrade-downgrade-cancel-account/#cancel]
+* [Backpack][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Backpack]
+* [Campfire][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Campfire]
+* [37Suite][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Suite]
+
+## What happens when you cancel?
+
+Cancellations are effective immediately, which means you will not be able to access your account after confirming the cancellation. If you want to save any content from your account, make sure to download them before canceling. Within 30 days, we permanently delete all content from our active systems and logs. Within 60 days, that content will also be permanently deleted from our backups. The data in backups are sparingly accessible, typically retrieved only for legal preservation requests. **Data can not be recovered once it has been permanently deleted.**
+
+If you cancel your account before the end of your current paid up month, you will not be charged again. We do not automatically prorate any unused time in the last billing cycle but if you have not used your account in a while, please do reach out to Support for a [fair refund][https://basecamp.com/about/policies/refund].
+
+## Basecamp-initiated cancellations
+
+In an effort to keep both your and our digital footprints smaller, Basecamp will auto-cancel your account if it has been inactive for an extended period:
+* For trial accounts: 30 days after a trial has expired without being upgraded
+* For frozen, previously paid accounts: 180 days after being frozen due to billing failures
+* For free accounts: after 365 days of inactivity
+
+Finally, per our [Terms of Service][https://basecamp.com/about/policies/terms], Basecamp does have the right to suspend or terminate your account for any reason at any time. In practice, this means we will cancel your account without notice if we have evidence that you are engaging in illegal behavior with our products such as spamming.

--- a/cancellation.md
+++ b/cancellation.md
@@ -21,7 +21,7 @@ If you cancel your account before the end of your current paid up month, you wil
 
 ## Basecamp-initiated cancellations
 
-In an effort to keep both your and our digital footprints smaller, Basecamp will auto-cancel your account if it has been inactive for an extended period:
+In an effort to keep both your and our digital footprints smaller, Basecamp may auto-cancel your account if it has been inactive for an extended period:
 * For trial accounts: 30 days after a trial has expired without being upgraded
 * For frozen, previously paid accounts: 180 days after being frozen due to billing failures
 * For free accounts: after 365 days of inactivity

--- a/cancellation.md
+++ b/cancellation.md
@@ -1,8 +1,8 @@
 # Cancellation policy
 
-*Last updated: September 16, 2019*
+*Last updated: September 17, 2019*
 
-We hope that you love your Basecamp product but if you decide you no longer need it, we believe it should be easy for you to cancel your subscription. That&rsquo;s why we&rsquo;ve made it easy for you to cancel directly via each application, no questions asked.
+We want satisfied customers, not hostages. That&rsquo;s why we make it easy for you to cancel your account directly in all of our apps — no phone calls required, no questions asked.
 
 Account owners can follow these instructions to cancel in-app:
 * [Basecamp 3][https://3.basecamp-help.com/article/156-cancel-your-basecamp-account]
@@ -15,15 +15,17 @@ Account owners can follow these instructions to cancel in-app:
 
 ## What happens when you cancel?
 
-Cancellations are effective immediately, which means you will not be able to access your account after confirming the cancellation. If you want to save any content from your account, make sure to download them before canceling. Within 30 days, we permanently delete all content from our active systems and logs. Within 60 days, that content will also be permanently deleted from our backups. The data in backups are sparingly accessible, typically retrieved only for legal preservation requests. **Data can not be recovered once it has been permanently deleted.**
+You won&rsquo;t be able to access your account once you cancel, so make sure you download everything you want to keep beforehand.
 
-If you cancel your account before the end of your current paid up month, you will not be charged again. We do not automatically prorate any unused time in the last billing cycle but if you have not used your account in a while, please do reach out to Support for a [fair refund][https://basecamp.com/about/policies/refund].
+We&rsquo;ll permanently delete your account data within 30 days from our servers and logs, and within 60 days from our backups. Retrieving data for a single account from a backup isn&rsquo;t possible, so if you change your mind you&rsquo;ll need to do it within the first 30 days. **Data can&rsquo;t be recovered once it has been permanently deleted.**
+
+We won&rsquo;t bill you again once you cancel. We don&rsquo;t automatically prorate any unused time you may have left but if you haven&rsquo;t used your account in months or just started a new billing cycle, [contact us][https://basecamp.com/support] for a [fair refund][https://basecamp.com/about/policies/refund]. We&rsquo;ll treat you right.
 
 ## Basecamp-initiated cancellations
 
-In an effort to keep both your and our digital footprints smaller, Basecamp may auto-cancel your account if it has been inactive for an extended period:
+Basecamp may cancel accounts if they have been inactive for an extended period:
 * For trial accounts: 30 days after a trial has expired without being upgraded
-* For frozen, previously paid accounts: 180 days after being frozen due to billing failures
+* For frozen accounts: 180 days after being frozen due to billing failures
 * For free accounts: after 365 days of inactivity
 
-Finally, per our [Terms of Service][https://basecamp.com/about/policies/terms], Basecamp does have the right to suspend or terminate your account for any reason at any time. In practice, this means we will cancel your account without notice if we have evidence that you are engaging in illegal behavior with our products such as spamming.
+Basecamp also retains the right to suspend or terminate accounts for any reason at any time, as outlined in our [Terms of Service][https://basecamp.com/about/policies/terms]. In practice, this means we will cancel your account without notice if we have evidence that you are using our products to engage in illegal behavior.

--- a/cancellation.md
+++ b/cancellation.md
@@ -6,7 +6,7 @@ We want satisfied customers, not hostages. That&rsquo;s why we make it easy for 
 
 Account owners can follow these instructions to cancel in-app:
 * [Basecamp 3](https://3.basecamp-help.com/article/156-cancel-your-basecamp-account)
-* [Basecamp 2](https://2.basecamp-help.com/article/243-canceling-and-pausing#cancel)
+* [Basecamp 2](https://2.basecamp-help.com/article/243-canceling-and-pausing#cancel): billing liaisons may also cancel Basecamp 2 accounts
 * [Basecamp Classic](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Basecamp)
 * [Highrise](https://help.highrisehq.com/account/upgrade-downgrade-cancel-account/#cancel)
 * [Backpack](https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Backpack)

--- a/cancellation.md
+++ b/cancellation.md
@@ -13,6 +13,8 @@ Account owners can follow these instructions to cancel in-app:
 * [Campfire][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Campfire]
 * [37Suite][https://help.37signals.com/billing/questions/316-information-about-adjusting-your-plan-or-canceling-your-account#Suite]
 
+Our legal responsibility is to account owners, which means we cannot cancel an account at the request of anyone else. If for whatever reason you no longer know who the account owner is, [contact us][https://basecamp.com/support]. We will gladly reach out to any current account owners at the email addresses we have on file.
+
 ## What happens when you cancel?
 
 You won&rsquo;t be able to access your account once you cancel, so make sure you download everything you want to keep beforehand.

--- a/terms.md
+++ b/terms.md
@@ -33,7 +33,7 @@ Customers may access their Service data via the Application Program Interface ("
 ## Cancellation and Termination
 
 1. You are solely responsible for properly canceling your account. An email or phone request to cancel your account is not considered cancellation. You can cancel your account at any time by clicking on the Account link in the global navigation bar at the top of the screen. The Account screen provides a simple no-questions-asked cancellation link.
-2. All of your content will be inaccessible from the Service immediately upon cancellation. Within 30 days, all content will be permanently deleted from backups and logs. This information can not be recovered once it has been permanently deleted.
+2. All of your content will be inaccessible from the Service immediately upon cancellation. Within 30 days, all content will be permanently deleted from active systems and logs. Within 60 days, all content will be permanently deleted from our backups. This information can not be recovered once it has been permanently deleted.
 3. If you cancel the Service before the end of your current paid up month, your cancellation will take effect immediately, and you will not be charged again. But there will not be any prorating of unused time in the last billing cycle.
 4. The Company, in its sole discretion, has the right to suspend or terminate your account and refuse any and all current or future use of the Service for any reason at any time. Such termination of the Service will result in the deactivation or deletion of your Account or your access to your Account, and the forfeiture and relinquishment of all content in your account. The Company reserves the right to refuse service to anyone for any reason at any time.
 


### PR DESCRIPTION
It's time for us to have a standalone cancellation policy. To date, our cancellation terms have been a section within our Terms of Service with hints sprinkled throughout other documents like the security white paper. 

We'll be elevating cancellations into its own policy, written in a more human tone. This policy lays out what happens to customer data when an account is canceled, introduces an auto-cancellation policy for accounts that are frozen for extended periods of time, and clarifies the extreme circumstances under which Basecamp would otherwise cancel an account.