### PR TITLE
Remove Clicky, add Mailchimp.

### DIFF
--- a/privacy/subprocessors.md
+++ b/privacy/subprocessors.md
@@ -5,9 +5,8 @@ Basecamp uses third party subprocessors, such as cloud computing providers and c
 Subprocessors located in the United States:
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
-* [Clicky](https://clicky.com/help/faq/privacy/gdpr). Web analytics service.
-* [Customer.io](https://customer.io/gdpr.html). Email newsletter service.
-* [Google Analytics](https://support.google.com/analytics/answer/6004245?hl=en). Web analytics service.
+* [Customer.io](https://customer.io/gdpr.html). Transactional email service.
+* [Mailchimp](https://mailchimp.com/gdpr/). Email newsletter service.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Sentry](https://blog.sentry.io/2018/03/14/gdpr-sentry-and-you). Error reporting software.


### PR DESCRIPTION
We're no longer using Clicky, so it's off the list. 

Separately, we _are_ using Mailchimp so I've added it to the list and changed the description for Customer.io to clarify how that service is being used.