### PR TITLE
Update spellings of GitHub

### DIFF
--- a/privacy/index.md
+++ b/privacy/index.md
@@ -133,6 +133,6 @@ If your Privacy Shield complaint cannot be resolved through these described chan
 
 ## Changes & questions
 
-We may update this policy as needed to comply with relevant regulations and reflect any new practices. You can view a history of the changes to our policies since mid-2018 [on Github](https://github.com/basecamp/policies/commits/master). Whenever we make a significant change to our policies, we will also announce them on our [company blog](https://m.signalvnoise.com/).
+We may update this policy as needed to comply with relevant regulations and reflect any new practices. You can view a history of the changes to our policies since mid-2018 [on GitHub](https://github.com/basecamp/policies/commits/master). Whenever we make a significant change to our policies, we will also announce them on our [company blog](https://m.signalvnoise.com/).
 
 Have any questions, comments, or concerns about this privacy policy, your data, or your rights with respect to your information? Please get in touch by emailing us at [privacy@basecamp.com](mailto:privacy@basecamp.com) and we’ll be happy to answer them!

--- a/terms/index.md
+++ b/terms/index.md
@@ -13,7 +13,7 @@ When we say “Company”, “we”, “our”, or “us” in this document, we
 
 When we say “Services”, we mean any product created and maintained by Basecamp, LLC. That includes Basecamp (all versions), HEY, Highrise, Campfire, Backpack, Ta-da List, and Writeboard, whether delivered within a web browser, desktop application, mobile application, or another format.
 
-We may update these Terms of Service in the future. You can track all changes made since mid-2018 [on Github](https://github.com/basecamp/policies/commits/master). Typically these changes have been to clarify some of these terms by linking to an expanded related policy. Whenever we make a significant change to our policies, we will also announce them on our [company blog](https://m.signalvnoise.com/).
+We may update these Terms of Service in the future. You can track all changes made since mid-2018 [on GitHub](https://github.com/basecamp/policies/commits/master). Typically these changes have been to clarify some of these terms by linking to an expanded related policy. Whenever we make a significant change to our policies, we will also announce them on our [company blog](https://m.signalvnoise.com/).
 
 When you use our Services, now or in the future, you are agreeing to the latest Terms of Service. That's true for any of our existing and future products and all features that we add to our Services over time. There may be times where we do not exercise or enforce any right or provision of the Terms of Service; in doing so, we are not waiving that right or provision. **These terms do contain a limitation of our liability.**
 


### PR DESCRIPTION
Spotted while reading HEY‘s policy:

<img width="792" alt="Screenshot 2020-06-17 13 58 54" src="https://user-images.githubusercontent.com/1000669/84856851-b240c080-b0a2-11ea-8dc8-482614b6325d.png">

