### PR TITLE
Add EU VAT as one of the ways we use billing address data

### DIFF
--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,7 +5,7 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: June 24, 2020*
+*Last updated: June 25, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
@@ -21,7 +21,7 @@ When you sign up for a Basecamp product, we typically ask for identifying inform
 
 ### Billing information
 
-When you pay for a Basecamp product, we ask for your credit card and billing address. That’s so we can charge you for service, calculate taxes due, and send you invoices. Your credit card is passed directly to our payment processor and doesn't ever go through our servers. We store a record of the payment transaction, including the last 4 digits of the credit card number and as-of billing address, for account history, invoicing, and billing support. We store your billing address to calculate any sales tax due in the United States, to detect fraudulent credit card transactions, and to print on your invoices.
+When you pay for a Basecamp product, we ask for your credit card and billing address. That’s so we can charge you for service, calculate taxes due, and send you invoices. Your credit card is passed directly to our payment processor and doesn't ever go through our servers. We store a record of the payment transaction, including the last 4 digits of the credit card number and as-of billing address, for account history, invoicing, and billing support. We store your billing address to calculate any sales tax due in the United States or VAT in the EU, to detect fraudulent credit card transactions, and to print on your invoices.
 
 ### Geolocation data
 

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,7 +5,7 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: June 8, 2020*
+*Last updated: June 24, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
@@ -21,7 +21,7 @@ When you sign up for a Basecamp product, we typically ask for identifying inform
 
 ### Billing information
 
-When you pay for a Basecamp product, we ask for your credit card and billing address. That's so we can charge you for service, calculate taxes due, and send you invoices. Your credit card is passed directly to our payment processor and doesn't ever go through our servers. We store a record of the payment transaction, including the last 4 digits of the credit card number and as-of billing address, for account history, invoicing, and billing support. We store your billing address to calculate any sales tax due in the United States, to detect fraudulent credit card transactions, and to print on your invoices.
+When you pay for a Basecamp product, we ask for your credit card and billing address. That’s so we can charge you for service, calculate taxes due, and send you invoices. Your credit card is passed directly to our payment processor and doesn't ever go through our servers. We store a record of the payment transaction, including the last 4 digits of the credit card number and as-of billing address, for account history, invoicing, and billing support. We store your billing address to calculate any sales tax due in the United States, to detect fraudulent credit card transactions, and to print on your invoices.
 
 ### Geolocation data
 
@@ -94,9 +94,11 @@ If you are in the EU, you can identify your specific authority to file a complai
 
 ## How we secure your data
 
-All data is encrypted via [SSL/TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) when transmitted from our servers to your browser. The database backups are also encrypted. Most data are not encrypted while they live in our database (since it needs to be ready to send to you when you need it), but we go to great lengths to secure your data at rest.
+All data is encrypted via [SSL/TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) when transmitted from our servers to your browser. The database backups are also encrypted.
 
-For more information about how we keep your information secure, please review our [security overview](../security/index.md).
+For products except HEY, most data are not encrypted while they live in our database (since it needs to be ready to send to you when you need it), but we go to great lengths to secure your data at rest. For more information about how we keep your information secure, please review our [security overview](../security/index.md).
+
+With HEY, the security overview still applies _and_ we’ve gone even further by encrypting the database at-work. Every field containing personal data is encrypted with its own key. The disks storing the data keys are encrypted as well. Our servers decrypt the data to send it to you when you need it. You can learn more about our approach towards security with HEY at [https://hey.com/security/](https://hey.com/security/).
 
 
 ## When you delete data in your product accounts

--- a/security/index.md
+++ b/security/index.md
@@ -31,6 +31,14 @@ Our software infrastructure is updated regularly with the latest security patche
 
 All credit card transactions are processed using secure encryption—the same level of encryption used by leading banks. Card information is transmitted, stored, and processed securely on a <a href="https://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard">PCI-Compliant network</a>.
 
+## Constant monitoring
+
+We have a team dedicated to maintaining your account’s security on our systems and monitoring tools we’ve set up to alert us to any nefarious activity against our domains. To date, we've _never_ had a data breach.
+
+We also audit internal data access. If a Basecamp employee wrongly accesses customer data, they will face penalties ranging from termination to prosecution. Again, to our knowledge, this hasn't happened.
+
+We have processes and defenses in place to keep our streak of 0 data breaches going. But in the unfortunate circumstances someone malicious does successfully mount an attack, we will immediately notify all affected customers.
+
 ## Over 20 years in business.
 
 We've been around the block and we've seen a lot of companies come and go. Security isn't just about technology, it's about trust. Since 1999, we've worked hard to earn the trust of over hundreds of thousands of companies world wide. We'll continue to work hard every day to maintain that trust. Longevity and stability is core to our mission at Basecamp.

--- a/security/index.md
+++ b/security/index.md
@@ -31,9 +31,9 @@ Our software infrastructure is updated regularly with the latest security patche
 
 All credit card transactions are processed using secure encryption—the same level of encryption used by leading banks. Card information is transmitted, stored, and processed securely on a <a href="https://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard">PCI-Compliant network</a>.
 
-## 20 years in business.
+## Over 20 years in business.
 
-We've been around the block and we've seen a lot of companies come and go. Security isn't just about technology, it's about trust. Over the past 20 years we've worked hard to earn the trust of over hundreds of thousands of companies world wide. We'll continue to work hard every day to maintain that trust. Longevity and stability is core to our mission at Basecamp.
+We've been around the block and we've seen a lot of companies come and go. Security isn't just about technology, it's about trust. Since 1999, we've worked hard to earn the trust of over hundreds of thousands of companies world wide. We'll continue to work hard every day to maintain that trust. Longevity and stability is core to our mission at Basecamp.
 
 ## Want to know more?
 

--- a/security/index.md
+++ b/security/index.md
@@ -37,7 +37,7 @@ We've been around the block and we've seen a lot of companies come and go. Secur
 
 ## Want to know more?
 
-[Read our security whitepaper](Basecamp Security Overview.pdf) for additional details.
+[Read our security whitepaper](Basecamp Security Overview.pdf) for additional details. We take even further security steps with HEY. Go to [https://hey.com/security/](https://hey.com/security/) to learn more.
 
 ## Have a concern? Need to report an incident?
 

--- a/security/index.md
+++ b/security/index.md
@@ -1,6 +1,6 @@
 ---
 title: Security overview
-description: Keeping customer data safe and secure is a huge responsibility and a top priority for us. Here's how we make it happen.
+description: Keeping customer data safe and secure is a huge responsibility and a top priority for us. Here’s how we make it happen.
 ---
 
 # Security overview.
@@ -33,15 +33,15 @@ All credit card transactions are processed using secure encryption—the same le
 
 ## Constant monitoring
 
-We have a team dedicated to maintaining your account’s security on our systems and monitoring tools we’ve set up to alert us to any nefarious activity against our domains. To date, we've _never_ had a data breach.
+We have a team dedicated to maintaining your account’s security on our systems and monitoring tools we’ve set up to alert us to any nefarious activity against our domains. To date, we’ve _never_ had a data breach.
 
-We also audit internal data access. If a Basecamp employee wrongly accesses customer data, they will face penalties ranging from termination to prosecution. Again, to our knowledge, this hasn't happened.
+We also audit internal data access. If a Basecamp employee wrongly accesses customer data, they will face penalties ranging from termination to prosecution. Again, to our knowledge, this hasn’t happened.
 
 We have processes and defenses in place to keep our streak of 0 data breaches going. But in the unfortunate circumstances someone malicious does successfully mount an attack, we will immediately notify all affected customers.
 
 ## Over 20 years in business.
 
-We've been around the block and we've seen a lot of companies come and go. Security isn't just about technology, it's about trust. Since 1999, we've worked hard to earn the trust of over hundreds of thousands of companies world wide. We'll continue to work hard every day to maintain that trust. Longevity and stability is core to our mission at Basecamp.
+We’ve been around the block and we’ve seen a lot of companies come and go. Security isn’t just about technology, it’s about trust. Since 1999, we’ve worked hard to earn the trust of over hundreds of thousands of companies world wide. We’ll continue to work hard every day to maintain that trust. Longevity and stability is core to our mission at Basecamp.
 
 ## Want to know more?
 


### PR DESCRIPTION
Oops, accidentally brought over duplicates of commits from https://github.com/basecamp/policies/pull/49. Compared to master now that that PR has merged, it’s just the one change:

_clarifying that we use billing address to determine EU VAT as well as US sales tax_