### PR TITLE
directly link to existing DPA in privacy policy

### DIFF
--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,7 +5,7 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: July 10, 2020*
+*Last updated: July 17, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
@@ -116,10 +116,15 @@ In many of our applications, we give you the option to trash data. Anything you 
 
 We also delete your data after an account is cancelled. In this case, there is no period of data being kept in an accessible trash can so your data are purged within 60 days. This applies both for cases when an account owner directly cancels and for auto-cancelled accounts. Please refer to our [Cancellation policy](../cancellation/index.md) for more details.
 
+## When transferring personal data from the EU
+
+The GDPR requires that any data transferred out of the EU must be treated with the same level of protection as EU privacy laws grant. The privacy laws of the United States generally do not meet that requirement. Therefore, we provide a standard Data Processing Addendum (DPA) that is [GDPR-compliant](https://gdpr-info.eu/art-28-gdpr/) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
+
+**✍️ [EU-based customers can sign the DPA online](https://app.hellosign.com/s/c0908a3d).**
 
 ## EU-US and Swiss-US Privacy Shield policy
 
-The GDPR requires that data transfer out of the EU must only happen to countries deemed as having adequate data protection laws. The United States generally doesn’t meet that requirement. [Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that allows for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary.
+[Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that allows for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary.
 
 ### We comply with the frameworks for EU, UK, and Swiss data that are transferred into the United States
 

--- a/privacy/regulations/index.md
+++ b/privacy/regulations/index.md
@@ -5,13 +5,15 @@ description: Privacy laws are in a lot of flux. Here’s info you should know.
 
 # Privacy Regulation Reference
 
+*Last updated: July 17, 2020*
+
 The data privacy regulatory landscape is undergoing a lot of change. You probably have heard about the EU General Data Protection Regulation (GDPR) that went into effect on May 25, 2018. There are also other regulations in the works around the world. We’ve written up this reference document to put information about our compliance with privacy regulations in one place.
 
 ## Are Basecamp products in compliance?
 
 First things first, you should view our full [Privacy policy](../index.md).
 
-- We are in compliance with the [General Data Protection Regulation (“GDPR”)](https://gdpr.eu/). We participate in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/) to safeguard the transfer of personal data to the US.
+- We are in compliance with the [General Data Protection Regulation (“GDPR”)](https://gdpr.eu/). For customers based in the EU, we offer a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) that include the European Commission’s Standard Contractual Clauses to safeguard the transfer of personal data to the US. We also participate in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/). You may have heard that on July 16, 2020, the Court of Justice of the European Union ruled that the Privacy Shield program was no longer valid as a mechanism for data transfer from the EU to the US. For now, we are continuing participation in the Privacy Shield program and are beginning to evaluate additional data transfer mechanisms.
 - We are in the process of ensuring compliance with the [California Consumer Privacy Act (“CCPA”)](https://www.oag.ca.gov/privacy/ccpa) and have expanded your rights in our privacy policy accordingly.
 - We are also watching and preparing for other legislation in the US and in other countries.
 
@@ -21,13 +23,13 @@ We are *not* [HIPAA](https://www.hhs.gov/hipaa/for-professionals/security/laws-r
 
 ## GDPR: data processing addendum
 
-Increasingly, privacy regulations require processing of personal data be governed by a data processing addendum (DPA) that is compliant with those regulations.
+Our data infrastructure are based in the US. That means if you are based in another country in the world and you use our products, your data is transferred to the US.
 
-We provide a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) (DPA) that is [GDPR-compliant](https://gdpr-info.eu/art-28-gdpr/) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed. If you use our products to process any EU personal data, you need to enter into GDPR-compliant data processing agreements with any online services and third party vendors you rely on, including Basecamp, LLC.
+The EU has stronger privacy laws than the US and a core tenant of the GDPR is that any EU personal data transferred out of the EU must be protected to the same level as guaranteed under EU law. For customers in the EU, we provide a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) (DPA) that is [GDPR-compliant](https://gdpr-info.eu/art-28-gdpr/) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed. If you use our products to process any EU personal data, you need to enter into GDPR-compliant data processing agreements with any online services and third party vendors you rely on, including Basecamp, LLC.
 
 **✍️ [Sign the DPA online](https://app.hellosign.com/s/c0908a3d).**
 
-Basecamp participates in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/participant?id=a2zt0000000TP1OAAW&status=Active) to safeguard the transfer of personal data to the US, meeting the GDPR requirement for adequate data protection laws.
+If you have any questions, comments, or concerns about our [Privacy policy](../index.md), your data, or your rights with respect to your information, please email us at [privacy@basecamp.com](mailto:privacy@basecamp.com).
 
 ## Subprocessors
 


### PR DESCRIPTION
Our DPA, offered since GDPR came into effect, include the Standard Contractual Clauses (SCC).