### PR TITLE
Update privacy regulations statement

### DIFF
--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,7 +5,7 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: August 5, 2020*
+*Last updated: August 6, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
@@ -70,7 +70,7 @@ Our default practice is to not access your information. The only times we’ll e
 Basecamp, LLC is a US company and all data infrastructure are located in the US.
 
 * If US law enforcement authorities have the necessary warrant, criminal subpoena, or court order requiring we share data, we have to comply. Otherwise, we flat-out reject requests from local and federal law enforcement when they seek data. And unless we’re legally prevented from it, we’ll always inform you when such requests are made. In the event a government authority outside the US approaches Basecamp with a request, our default stance is to refuse unless the US government compels us to comply through procedures outlined in a mutual legal assistance treaty or agreement. ***We have never received a National Security Letter or Foreign Intelligence Surveillance Act (FISA) order.***
-* Similarly, If Basecamp receives a request to preserve data, we refuse unless compelled by either the US Federal Stored Communications Act, 18 U.S.C. Section 2703(f) or a properly served US subpoena for civil matters. In both of these situations, we have to comply. In these situations, we notify affected customers as soon as possible unless we are legally prohibited from doing so. We do not share preserved data unless absolutely required under the Stored Communications Act or compelled by a court order that we choose not to appeal. Furthermore, unless we receive a proper warrant, court order, or subpoena before the required preservation period expires, we destroy any preserved copies we made of customer data once the preservation period lapses.
+* Similarly, if Basecamp receives a request to preserve data, we refuse unless compelled by either the US Federal Stored Communications Act, 18 U.S.C. Section 2703(f) or a properly served US subpoena for civil matters. In both of these situations, we have to comply. In these situations, we notify affected customers as soon as possible unless we are legally prohibited from doing so. We do not share preserved data unless absolutely required under the Stored Communications Act or compelled by a court order that we choose not to appeal. Furthermore, unless we receive a proper warrant, court order, or subpoena before the required preservation period expires, we destroy any preserved copies we made of customer data once the preservation period lapses.
 * If we get an informal request from any person, organization, or entity, we do not assist. If you are an account owner who wants to export data from their accounts, you can do so directly by following these instructions for [HEY](https://hey.com/faqs/#if-i-don-t-like-hey-can-i-export-my-email-and-contacts), [Basecamp 3](https://3.basecamp-help.com/article/150-export-your-basecamp-data), [Basecamp 2](https://2.basecamp-help.com/article/247-exporting-account-data), [Basecamp Classic](https://help.basecamp.com/basecamp/questions/164-can-we-export-our-basecamp-classic-data), [Highrise](https://help.highrisehq.com/imports-exports/), [Campfire](https://help.basecamp.com/campfire/questions/482-can-i-export-my-data-out-of-campfire), and [Backpack](https://help.37signals.com/backpack/questions/255-can-i-export-my-data-out-of-backpack).
 
 Finally, if Basecamp, LLC is acquired by or merged with another company — we don’t plan on that, but if it happens — we’ll notify you well before any info about you is transferred and becomes subject to a different privacy policy.
@@ -84,7 +84,7 @@ At Basecamp, we apply the same data rights to all customers, regardless of their
 * **Right to Correction.** You have the right to request correction of your personal information.
 * **Right to Erasure / “To be Forgotten”.** This is your right to request, subject to certain limitations under applicable law, that your personal information be erased from our possession and, by extension, all of our service providers. Fulfillment of some data deletion requests may prevent you from using Basecamp services because our applications may then no longer work. In such cases, a data deletion request may result in closing your account.
 * **Right to Complain.** You have the right to make a complaint regarding our handling of your personal information with the appropriate supervisory authority. To identify your specific authority or find out more about this right, EU individuals should go to [https://edpb.europa.eu/about-edpb/board/members_en](https://edpb.europa.eu/about-edpb/board/members_en).
-* **Right to Restrict Processing.** This is your right to request restriction of how and why your personal information is used or processed, including opting out of sale of personal information. (Again: we never have and never will sell your personal data).
+* **Right to Restrict Processing.** This is your right to request restriction of how and why your personal information is used or processed, including opting out of sale of personal information. (Again: we never have and never will sell your personal data.)
 * **Right to Object.** You have the right, in certain situations, to object to how or why your personal information is processed.
 * **Right to Portability.** You have the right to receive the personal information we have about you and the right to transmit it to another party.
 * **Right to not be subject to Automated Decision-Making.** You have the right to object and prevent any decision that could have a legal, or similarly significant, effect on you from being made solely based on automated processes. This right is limited, however, if the decision is necessary for performance of any contract between you and us, is allowed by applicable law, or is based on your explicit consent.
@@ -112,11 +112,11 @@ We also delete your data after an account is cancelled. In this case, there is n
 
 ## Location of site and data
 
-Our products and other web properties are operated in the United States. If you are located in the European Union or elsewhere outside of the United States, please be aware that any information you provide to us will be transferred to the United States. By using our Site, participating in any of our services and/or providing us with your information, you consent to this transfer.
+Our products and other web properties are operated in the United States. If you are located in the European Union or elsewhere outside of the United States, **please be aware that any information you provide to us will be transferred to and stored in the United States**. By using our Site, participating in any of our services and/or providing us with your information, you consent to this transfer.
 
 ## When transferring personal data from the EU
 
-The GDPR requires that any data transferred out of the EU must be treated with the same level of protection as EU privacy laws grant. The privacy laws of the United States generally do not meet that requirement. That is why since GDPR went into effect, Basecamp has offered a data processing addendum and voluntarily participated in the EU-US and Swiss-US Privacy Shield Framework.
+The GDPR requires that any data transferred out of the EU must be treated with the same level of protection that the EU privacy laws grant. The privacy laws of the United States generally do not meet that requirement. That is why since GDPR went into effect, Basecamp has offered a data processing addendum and voluntarily participated in the EU-US Privacy Shield Framework as well as the Swiss-US Privacy Shield Framework.
 
 Our data processing addendum include the European Commission’s Standard Contractual Clauses to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
 
@@ -124,7 +124,7 @@ Our data processing addendum include the European Commission’s Standard Contra
 
 ## EU-US and Swiss-US Privacy Shield policy
 
-[Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that up until July 16, 2020, allowed for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary.
+The EU-US [Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that up until July 16, 2020, allowed for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary. The Swiss-US Privacy Shield is a similar program for data transferred to the US from Switzerland and is still in effect.
 
 ### We comply with the frameworks for EU, UK, and Swiss data that are transferred into the United States
 
@@ -141,11 +141,11 @@ The Privacy Shield Frameworks uphold specific principles, many of which are alre
 
 ### We commit to resolving all complaints
 
-In compliance with the EU-US and Swiss-US Privacy Shield Principles, we commit to resolve complaints about your privacy and our collection or use of your personal information. European Union, United Kingdom, or Swiss individuals with inquiries or complaints regarding this privacy policy should first contact Jeremy Daer at Basecamp at privacy@basecamp.com, or by mail at Basecamp, LLC, 2045 W Grand Ave Ste B, PMB 53289, Chicago, IL 60612 USA.
+In compliance with the EU-US Privacy Shield Principles and the Swiss-US Privacy Shield Principles, we commit to resolve complaints about your privacy and our collection or use of your personal information. European Union, United Kingdom, or Swiss individuals with inquiries or complaints regarding this privacy policy should first contact Jeremy Daer at Basecamp at privacy@basecamp.com, or by mail at Basecamp, LLC, 2045 W Grand Ave Ste B, PMB 53289, Chicago, IL 60612 USA.
 
-Basecamp (the company) has further committed to refer unresolved privacy complaints under the EU-US and Swiss-US Privacy Shield Principles to an independent dispute resolution mechanism, the BBB EU PRIVACY SHIELD, operated by BBB National Programs. If you do not receive timely acknowledgment of your complaint, or if your complaint is not satisfactorily addressed, please visit [https://bbbprograms.org/privacy-shield-complaints/](https://bbbprograms.org/privacy-shield-complaints/) for more information and to file a complaint. This service is provided at no cost to you. Please do not submit GDPR complaints to BBB EU Privacy Shield.
+Basecamp (the company) has further committed to refer unresolved privacy complaints under the EU-US Privacy Shield Principles and the Swiss-US Privacy Shield Principles to an independent dispute resolution mechanism, the BBB EU PRIVACY SHIELD, operated by BBB National Programs. If you do not receive timely acknowledgment of your complaint, or if your complaint is not satisfactorily addressed, please visit [https://bbbprograms.org/privacy-shield-complaints/](https://bbbprograms.org/privacy-shield-complaints/) for more information and to file a complaint. This service is provided at no cost to you. Please do not submit GDPR complaints to BBB EU Privacy Shield.
 
-If your Privacy Shield complaint cannot be resolved through these described channels, under certain conditions, you may invoke binding arbitration for some residual claims not resolved by other redress mechanisms. To learn more, please view the Privacy Shield Annex 1 at [https://www.privacyshield.gov/article?id=ANNEX-I-introduction](https://www.privacyshield.gov/article?id=ANNEX-I-introduction).
+If your EU-US Privacy Shield complaint cannot be resolved through these described channels, under certain conditions, you may invoke binding arbitration for some residual claims not resolved by other redress mechanisms. To learn more, please view the Privacy Shield Annex 1 at [https://www.privacyshield.gov/article?id=ANNEX-I-introduction](https://www.privacyshield.gov/article?id=ANNEX-I-introduction).
 
 ## Changes & questions
 

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,11 +5,11 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: July 30, 2020*
+*Last updated: August 5, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
-This policy applies to all products built and maintained by Basecamp LLC including Basecamp (all versions), HEY, Highrise, Campfire, Backpack, Ta-da List, and Writeboard.
+This policy applies to all products built and maintained by Basecamp LLC including Basecamp (all versions), HEY, Highrise, Campfire, Backpack, Ta-da List, and Writeboard. For candidates applying to jobs at Basecamp LLC, please review our [Recruitment Privacy policy](recruitment/index.md).
 
 ## What we collect and why
 
@@ -75,11 +75,7 @@ Basecamp, LLC is a US company and all data infrastructure are located in the US.
 
 Finally, if Basecamp, LLC is acquired by or merged with another company — we don’t plan on that, but if it happens — we’ll notify you well before any info about you is transferred and becomes subject to a different privacy policy.
 
-## Location of Site and Data
-
-Our products and other web properties are operated in the United States. If you are located in the European Union or elsewhere outside of the United States, please be aware that any information you provide to us will be transferred to the United States. By using our Site, participating in any of our services and/or providing us with your information, you consent to this transfer.
-
-## Your Rights With Respect to Your Information
+## Your rights with respect to your information
 
 At Basecamp, we apply the same data rights to all customers, regardless of their location. Currently some of the most privacy-forward regulations in place are the European Union’s General Data Protection Regulation (“GDPR”) and California Consumer Privacy Act (“CCPA”) in the US. Basecamp recognizes all of the rights granted in these regulations, except as limited by applicable law. These rights include:
 
@@ -100,7 +96,6 @@ If you have questions about exercising these rights or need assistance, please c
 
 If you are in the EU, you can identify your specific authority to file a complaint or find out more about GDPR, at [https://edpb.europa.eu/about-edpb/board/members_en](https://edpb.europa.eu/about-edpb/board/members_en).
 
-
 ## How we secure your data
 
 All data is encrypted via [SSL/TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) when transmitted from our servers to your browser. The database backups are also encrypted.
@@ -109,22 +104,27 @@ For products except HEY, most data are not encrypted while they live in our data
 
 With HEY, the security overview still applies _and_ we’ve gone even further by encrypting the database at-work. Every field containing personal data is encrypted with its own key. The disks storing the data keys are encrypted as well. Our servers decrypt the data to send it to you when you need it. You can learn more about our approach towards security with HEY at [https://hey.com/security/](https://hey.com/security/).
 
-
-## When you delete data in your product accounts
+## What happens when you delete data in your product accounts
 
 In many of our applications, we give you the option to trash data. Anything you trash on your product accounts while they are active will be kept in an accessible trash can for up to 30 days (it varies a little by product). After that, the trashed data are no longer accessible via the application and are deleted from our active servers within the next 30 days. We also have some backups of our application databases, which are kept for up to another 30 days. In total, when you trash things in our applications, they are purged within 90 days from all of our systems and logs. Retrieving data for a single account from a backup is cost-prohibitive and unduly burdensome so if you change your mind you’ll need to do so before your data are deleted from our active servers.
 
 We also delete your data after an account is cancelled. In this case, there is no period of data being kept in an accessible trash can so your data are purged within 60 days. This applies both for cases when an account owner directly cancels and for auto-cancelled accounts. Please refer to our [Cancellation policy](../cancellation/index.md) for more details.
 
+## Location of site and data
+
+Our products and other web properties are operated in the United States. If you are located in the European Union or elsewhere outside of the United States, please be aware that any information you provide to us will be transferred to the United States. By using our Site, participating in any of our services and/or providing us with your information, you consent to this transfer.
+
 ## When transferring personal data from the EU
 
-The GDPR requires that any data transferred out of the EU must be treated with the same level of protection as EU privacy laws grant. The privacy laws of the United States generally do not meet that requirement. Therefore, we provide a standard Data Processing Addendum (DPA) that is [GDPR-compliant](https://gdpr-info.eu/art-28-gdpr/) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
+The GDPR requires that any data transferred out of the EU must be treated with the same level of protection as EU privacy laws grant. The privacy laws of the United States generally do not meet that requirement. That is why since GDPR went into effect, Basecamp has offered a data processing addendum and voluntarily participated in the EU-US and Swiss-US Privacy Shield Framework.
+
+Our data processing addendum include the European Commission’s Standard Contractual Clauses to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
 
 **✍️ [EU-based customers can sign the DPA online](https://app.hellosign.com/s/c0908a3d).**
 
 ## EU-US and Swiss-US Privacy Shield policy
 
-[Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that allows for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary.
+[Privacy Shield](https://www.privacyshield.gov/) is an agreement between certain European jurisdictions and the United States that up until July 16, 2020, allowed for the transfer of personal data from the EU to the US. Participation in the Privacy Shield program is voluntary.
 
 ### We comply with the frameworks for EU, UK, and Swiss data that are transferred into the United States
 

--- a/privacy/recruitment/index.md
+++ b/privacy/recruitment/index.md
@@ -1,0 +1,51 @@
+---
+title: Recruitment Privacy policy
+description: The rundown on what happens to your job application.
+---
+
+# Recruitment Privacy policy
+
+*Last updated: August 5, 2020*
+
+## What we collect, where we store it, and how long we keep it
+
+When you apply for a job at Basecamp (the company), we may store your data in two places. 1) When you apply, your information is collected via an application form in [Workable](https://www.workable.com/), our applicant tracking system. 2) If you progress to later selection stages, your information is colocated in Basecamp (the application). Candidate data we collect and process in Workable and Basecamp are used for selection purposes only. Access to your personal information is limited to Basecamp employees who participate in the selection process.
+
+We collect and store these data because we have a legitimate interest: we are trying to hire for a position and we need information from any candidate who applies for the role. If you apply for a job at Basecamp, we ask for your explicit consent so that we can accept your application information, transfer it to the US, and review your candidacy.
+
+For more information about your rights to your data, please view our general [privacy policy](../index.md); all the rights outlined there also apply to your data as a candidate.
+
+We keep records in Workable for all applicants, and Workable records consist of:
+
+* Your job application materials (full name, e-mail address, your answers to any short answer questions required in the application, your cover letter, your CV/resume);
+* Internal assessment notes about your application;
+* Emails with you concerning the selection process.
+
+We keep records in Basecamp for some applicants, only those who progress to later selection rounds, and Basecamp records consist of:
+
+* Your job application materials (full name, e-mail address, your answers to any short answer questions required in the application, your cover letter, your CV/resume);
+* Internal assessment notes about your application and interviews;
+* Reference contact information and notes on the results of reference checks.
+
+We store your data in Workable and in Basecamp for one year. You may ask us to access, correct, update, or delete your data at any time by emailing Andrea LaRowe, [andrea@basecamp.com](mailto:andrea@basecamp.com).
+
+If we want to keep your information for longer than one year (for instance, if we think we may want to contact you for a future open position), we'll request your explicit consent via email to continue to store your personal data with an updated time frame.
+
+If you submit an unsolicited job application through a channel other than Workable, you'll receive direction to re-submit your application through Workable. Any personal information you've included, like a resume, will be immediately deleted.
+
+If you have questions about your personal data as a job applicant, you can contact:
+Basecamp, LLC
+Andrea LaRowe, andrea@basecamp.com
+2045 W Grand Ave Ste B
+PMB 53289
+Chicago, IL 60612
+
+If you are in the EU, you can identify your specific authority to file a GDPR complaint at https://edpb.europa.eu/about-edpb/board/members_en.
+
+Complete information about how Workable responsibly stores your data can be found in [their privacy policy](https://www.workable.com/privacy). Complete information about how we protect all data stored within Basecamp can be found in our [Privacy policy](../index.md) and [Security overview](../../index.md).
+
+## Changes & questions
+
+We may update this policy as needed to comply with relevant regulations and reflect any new practices. You can view a history of the changes to our policies since mid-2018 [on GitHub](https://github.com/basecamp/policies/commits/master). Whenever we make a significant change to our policies, we will also announce them on our [company blog](https://m.signalvnoise.com/).
+
+Have any questions, comments, or concerns about this privacy policy, your data, or your rights with respect to your information? Please get in touch by emailing us at [privacy@basecamp.com](mailto:privacy@basecamp.com).

--- a/privacy/recruitment/index.md
+++ b/privacy/recruitment/index.md
@@ -5,7 +5,7 @@ description: The rundown on what happens to your job application.
 
 # Recruitment Privacy policy
 
-*Last updated: August 5, 2020*
+*Last updated: August 6, 2020*
 
 ## What we collect, where we store it, and how long we keep it
 
@@ -27,20 +27,18 @@ We keep records in Basecamp for some applicants, only those who progress to late
 * Internal assessment notes about your application and interviews;
 * Reference contact information and notes on the results of reference checks.
 
-We store your data in Workable and in Basecamp for one year. You may ask us to access, correct, update, or delete your data at any time by emailing Andrea LaRowe, [andrea@basecamp.com](mailto:andrea@basecamp.com).
-
-If we want to keep your information for longer than one year (for instance, if we think we may want to contact you for a future open position), we'll request your explicit consent via email to continue to store your personal data with an updated time frame.
+We store your data in Workable and in Basecamp until we successfully fill the open position. If we want to keep your information for longer than that — for instance, if we think we may want to contact you for a future open position — we'll request your explicit consent via email to continue to store your personal data with an updated time frame. You may ask us to access, correct, update, or delete your data at any time by emailing Andrea LaRowe, [andrea@basecamp.com](mailto:andrea@basecamp.com).
 
 If you submit an unsolicited job application through a channel other than Workable, you'll receive direction to re-submit your application through Workable. Any personal information you've included, like a resume, will be immediately deleted.
 
 If you have questions about your personal data as a job applicant, you can contact:
 Basecamp, LLC
-Andrea LaRowe, andrea@basecamp.com
+Andrea LaRowe, [andrea@basecamp.com](mailto:andrea@basecamp.com)
 2045 W Grand Ave Ste B
 PMB 53289
 Chicago, IL 60612
 
-If you are in the EU, you can identify your specific authority to file a GDPR complaint at https://edpb.europa.eu/about-edpb/board/members_en.
+If you are in the EU, you can identify your specific authority to file a GDPR complaint at [https://edpb.europa.eu/about-edpb/board/members_en](https://edpb.europa.eu/about-edpb/board/members_en).
 
 Complete information about how Workable responsibly stores your data can be found in [their privacy policy](https://www.workable.com/privacy). Complete information about how we protect all data stored within Basecamp can be found in our [Privacy policy](../index.md) and [Security overview](../../index.md).
 

--- a/privacy/regulations/index.md
+++ b/privacy/regulations/index.md
@@ -1,11 +1,11 @@
 ---
-title: Privacy Regulation Reference
+title: Privacy Regulations Reference
 description: Privacy laws are in a lot of flux. Here’s info you should know.
 ---
 
-# Privacy Regulation Reference
+# Privacy Regulations Reference
 
-*Last updated: August 5, 2020*
+*Last updated: August 6, 2020*
 
 The data privacy regulatory landscape is undergoing a lot of change. You probably have heard about the EU General Data Protection Regulation (GDPR) that went into effect on May 25, 2018. There are also other regulations in effect or in the works around the world. We’ve written up this reference document to put helpful information regarding our products and privacy regulations in one place. Please also view our full [Privacy policy](../index.md).
 
@@ -13,7 +13,7 @@ If you have any questions, comments, or concerns about our [Privacy policy](../i
 
 ## European Union General Data Protection Regulation (GDPR)
 
-Basecamp is an American company and our data infrastructure are currently based in the US. That means if you are based in another country in the world and you use our products, your data are transferred to the US. The EU has stronger privacy laws than the US and a core tenant of the GDPR is that any EU personal data transferred out of the EU must be protected to the same level as guaranteed under EU law. With that aim, since GDPR went into effect Basecamp has offered a data processing addendum and voluntarily participated in the EU-US and Swiss-US Privacy Shield Framework.
+Basecamp is an American company and our data infrastructure are currently based in the US. That means if you are based in another country in the world and you use our products, your data are transferred to the US. The EU has stronger privacy laws than the US and a core tenant of the GDPR is that any EU personal data transferred out of the EU must be protected to the same level as guaranteed under EU law. With that aim, since GDPR went into effect Basecamp has offered a data processing addendum and voluntarily participated in the EU-US Privacy Shield Framework and the Swiss-US Privacy Shield Framework.
 
 ### Data processing addendum
 
@@ -25,7 +25,7 @@ On July 16, 2020, the Court of Justice of the European Union made a ruling, coll
 
 ### A note about Privacy Shield
 
-Since its establishment, Basecamp has also voluntarily participated in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/). The same Schrems II ruling from the Court of Justice of the European Union invalidated the Privacy Shield program as a mechanism for data transfer from the EU to the US. This ruling does not apply to the Swiss-US Privacy Shield. We are still certified under the Privacy Shield Framework.
+Since its establishment, Basecamp has also voluntarily participated in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/). The same Schrems II ruling from the Court of Justice of the European Union invalidated the EU-US Privacy Shield program as a mechanism for data transfer from the EU to the US. This ruling does not apply to the Swiss-US Privacy Shield. We are still certified under, and follow, both Privacy Shield Frameworks.
 
 ## California Consumer Privacy Act (CCPA)
 

--- a/privacy/regulations/index.md
+++ b/privacy/regulations/index.md
@@ -5,35 +5,43 @@ description: Privacy laws are in a lot of flux. Here’s info you should know.
 
 # Privacy Regulation Reference
 
-*Last updated: July 17, 2020*
+*Last updated: August 5, 2020*
 
-The data privacy regulatory landscape is undergoing a lot of change. You probably have heard about the EU General Data Protection Regulation (GDPR) that went into effect on May 25, 2018. There are also other regulations in the works around the world. We’ve written up this reference document to put information about our compliance with privacy regulations in one place.
-
-## Are Basecamp products in compliance?
-
-First things first, you should view our full [Privacy policy](../index.md).
-
-- We are in compliance with the [General Data Protection Regulation (“GDPR”)](https://gdpr.eu/). For customers based in the EU, we offer a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) that include the European Commission’s Standard Contractual Clauses to safeguard the transfer of personal data to the US. We also participate in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/). You may have heard that on July 16, 2020, the Court of Justice of the European Union ruled that the Privacy Shield program was no longer valid as a mechanism for data transfer from the EU to the US. For now, we are continuing participation in the Privacy Shield program and are beginning to evaluate additional data transfer mechanisms.
-- We are in the process of ensuring compliance with the [California Consumer Privacy Act (“CCPA”)](https://www.oag.ca.gov/privacy/ccpa) and have expanded your rights in our privacy policy accordingly.
-- We are also watching and preparing for other legislation in the US and in other countries.
-
-We will update this document as we ensure compliance with other regulations.
-
-We are *not* [HIPAA](https://www.hhs.gov/hipaa/for-professionals/security/laws-regulations/index.html)-compliant and currently do not have plans to become so.
-
-## GDPR: data processing addendum
-
-Our data infrastructure are based in the US. That means if you are based in another country in the world and you use our products, your data is transferred to the US.
-
-The EU has stronger privacy laws than the US and a core tenant of the GDPR is that any EU personal data transferred out of the EU must be protected to the same level as guaranteed under EU law. For customers in the EU, we provide a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) (DPA) that is [GDPR-compliant](https://gdpr-info.eu/art-28-gdpr/) to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed. If you use our products to process any EU personal data, you need to enter into GDPR-compliant data processing agreements with any online services and third party vendors you rely on, including Basecamp, LLC.
-
-**✍️ [Sign the DPA online](https://app.hellosign.com/s/c0908a3d).**
+The data privacy regulatory landscape is undergoing a lot of change. You probably have heard about the EU General Data Protection Regulation (GDPR) that went into effect on May 25, 2018. There are also other regulations in effect or in the works around the world. We’ve written up this reference document to put helpful information regarding our products and privacy regulations in one place. Please also view our full [Privacy policy](../index.md).
 
 If you have any questions, comments, or concerns about our [Privacy policy](../index.md), your data, or your rights with respect to your information, please email us at [privacy@basecamp.com](mailto:privacy@basecamp.com).
 
+## European Union General Data Protection Regulation (GDPR)
+
+Basecamp is an American company and our data infrastructure are currently based in the US. That means if you are based in another country in the world and you use our products, your data are transferred to the US. The EU has stronger privacy laws than the US and a core tenant of the GDPR is that any EU personal data transferred out of the EU must be protected to the same level as guaranteed under EU law. With that aim, since GDPR went into effect Basecamp has offered a data processing addendum and voluntarily participated in the EU-US and Swiss-US Privacy Shield Framework.
+
+### Data processing addendum
+
+For customers in the EU, we provide a standard [Data Processing Addendum](https://app.hellosign.com/s/c0908a3d) (DPA) that include the European Commission’s Standard Contractual Clauses to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed.
+
+**✍️ [Sign the DPA online](https://app.hellosign.com/s/c0908a3d).**
+
+On July 16, 2020, the Court of Justice of the European Union made a ruling, colloquially called "Schrems II", that declared that when personal data is transferred from the EU to a country with mass-surveillance laws, such as the US, China, or Russia, the Standard Contractual Clauses are not necessarily adequate. This ruling has opened up a lot of questions and it applies to virtually every American software service, which are subject to the US Foreign Intelligence Surveillance Act (FISA). Data Protection Authorities across the EU are beginning to issue follow-up guidance. This [crowdsourced webpage](https://iapp.org/resources/article/dpa-and-government-guidance-on-schrems-ii-2/) lists statements made by different Data Protection Authorities to date. We are investigating other measures we could take and are looking out for practical guidance from a variety of Data Protection Authorities in the EU.
+
+### A note about Privacy Shield
+
+Since its establishment, Basecamp has also voluntarily participated in the [EU-US and Swiss-US Privacy Shield Framework](https://www.privacyshield.gov/). The same Schrems II ruling from the Court of Justice of the European Union invalidated the Privacy Shield program as a mechanism for data transfer from the EU to the US. This ruling does not apply to the Swiss-US Privacy Shield. We are still certified under the Privacy Shield Framework.
+
+## California Consumer Privacy Act (CCPA)
+
+In the CCPA, there is an important distinction between what are referred to as “service providers”, “businesses”, and “third parties”. You can see how the regulation defines these words by visiting the California Attorney General’s website: https://www.oag.ca.gov/privacy/ccpa.
+
+*Under the CCPA, Basecamp is a “service provider.”* That means when we process data you provide, we do so solely for the purpose you signed up for. Our business model is simple: we charge a recurring subscription fee to our customers. We do not sell personal information or use your data for any other commercial purposes unless with your explicit permission.
+
+The CCPA also grants residents of California with additional rights related to their information. We grant those rights to all of our customers and detail them in our Privacy policy. Our Privacy policy also explains the information we collect in order to provide our services and clearly lists the only times we access or share your data.
+
+## US Health Insurance Portability and Accountability Act (HIPAA)
+
+Our products are currently *not* [HIPAA](https://www.hhs.gov/hipaa/for-professionals/security/laws-regulations/index.html)-compliant and we do not have immediate plans to become so.
+
 ## Subprocessors
 
-Basecamp uses third party subprocessors, such as cloud computing providers and customer support software, to provide our services. We enter into GDPR-compliant data processing agreements with each subprocessor, and require the same of them.
+Basecamp uses third party subprocessors, such as cloud computing providers and customer support software, to provide our services. We enter into data processing agreements including GDPR Standard Contractual Clauses with each subprocessor, and require the same of them.
 
 You can see which subprocessors we use by application by viewing the following linked lists:
 
@@ -44,11 +52,3 @@ You can see which subprocessors we use by application by viewing the following l
 * [Backpack subprocessors](../backpack-subprocessors/index.md)
 
 We also use other software as a company that are not part of providing our services but may collect your personal information for other purposes. You can view this list of processors in the following page: [Company processors](../company-processors/index.md)
-
-## CCPA: our role as a service provider
-
-In the CCPA, there is an important distinction between what are referred to as “service providers”, “businesses”, and “third parties”. You can see how the regulation defines these words by visiting the California Attorney General’s website: https://www.oag.ca.gov/privacy/ccpa.
-
-Under the CCPA, Basecamp is a “service provider.” That means when we process data you provide, we do so solely for the purpose you signed up for. Our business model is simple: we charge a recurring subscription fee to our customers. We do not sell personal information or use your data for any other commercial purposes unless with your explicit permission.
-
-The CCPA also grants residents of California with additional rights related to their information. We grant those rights to all of our customers and detail them in our Privacy policy. Our Privacy policy also explains the information we collect in order to provide our services and clearly lists the only times we access or share your data.


### PR DESCRIPTION
This PR does two main things:

1. Adds a recruitment-specific privacy policy
2. Adds more context around Schrems II in our privacy policy.

In a subsequent update, we’ll also roll in our standard contractual clauses directly into our Terms of Service for EU/EEA customers.