### PR TITLE
Introduce Rollbar as a HEY subprocessor for error reporting

### DIFF
--- a/privacy/hey-subprocessors/index.md
+++ b/privacy/hey-subprocessors/index.md
@@ -15,6 +15,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [hCaptcha](https://hcaptcha.com/privacy). Anti-bot and spam protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Mailchimp](https://mailchimp.com/gdpr/). Email newsletter service.
+* [Rollbar](https://rollbar.com/compliance/gdpr/). Error reporting software.
 * [Sentry](https://blog.sentry.io/2018/03/14/gdpr-sentry-and-you). Error reporting software.
 * [TaxJar](https://support.taxjar.com/article/526-taxjar-security-and-privacy-questions). Sales tax calculation.
 * [Zapier](https://zapier.com/help/account/data-management/data-privacy-at-zapier). Software integration service.


### PR DESCRIPTION
DPA signed 2020-08-31.

We use Rollbar to track & report on internal system errors in HEY.

Error data reported to Rollbar includes information about the web
request that triggered the error and about the internal system state
at the time of the error.

We scrub sensitive and personal data before sending to Rollbar.
However, we may miss some source of personal data, so we treat Rollbar
as a subprocessor and signed a DPA with them.