### PR TITLE
add reCAPTCHA to subprocessor list

### DIFF
--- a/privacy/backpack-subprocessors/index.md
+++ b/privacy/backpack-subprocessors/index.md
@@ -12,6 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
+* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [TaxJar](https://support.taxjar.com/article/526-taxjar-security-and-privacy-questions). Sales tax calculation.
 * [Twilio](https://www.twilio.com/gdpr). Text messaging service.

--- a/privacy/basecamp-subprocessors/index.md
+++ b/privacy/basecamp-subprocessors/index.md
@@ -13,6 +13,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Customer.io](https://customer.io/gdpr.html). Transactional email service.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
+* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Mailchimp](https://mailchimp.com/gdpr/). Transactional email service.
 * [Sentry](https://blog.sentry.io/2018/03/14/gdpr-sentry-and-you). Error reporting software.

--- a/privacy/campfire-subprocessors/index.md
+++ b/privacy/campfire-subprocessors/index.md
@@ -12,6 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
+* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [TaxJar](https://support.taxjar.com/article/526-taxjar-security-and-privacy-questions). Sales tax calculation.
 * [Twilio](https://www.twilio.com/gdpr). Text messaging service.

--- a/privacy/highrise-subprocessors/index.md
+++ b/privacy/highrise-subprocessors/index.md
@@ -12,6 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
+* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Heroku](https://devcenter.heroku.com/articles/gdpr). Cloud services provider.
 * [Mailgun](https://www.mailgun.com/gdpr/). Email service provider.

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -5,7 +5,7 @@ description: The privacy of your data — and it is your data, not ours! — is 
 
 # Privacy policy
 
-*Last updated: December 4, 2020*
+*Last updated: December 9, 2020*
 
 The privacy of your data — and it is your data, not ours! — is a big deal to us. In this policy, we lay out: what data we collect and why; how your data is handled; and your rights to your data. We promise we never sell your data: never have, never will.
 
@@ -39,7 +39,7 @@ Historically — including within the last 12 months — we have used third-part
 
 ### Anti-bot assessments
 
-We use [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) services with HEY as a means of spam protection. We have a legitimate interest in protecting our app and the broader Internet community from spam. When you fill specific forms in HEY, the CAPTCHA service evaluates various information (e.g IP address, how long the visitor has been on the app, mouse movements) to check whether the data is possibly filled out by an automated program instead of a human. We retain these data via our subprocessor forever because they are used for anti-spam mitigation.
+We use [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) services across our applications to mitigate brute force logins and in HEY as a means of spam protection. We have a legitimate interest in protecting our apps and the broader Internet community from credential stuffing attacks and spam. When you log into your accounts and fill specific forms in HEY, the CAPTCHA service evaluates various information (e.g IP address, how long the visitor has been on the app, mouse movements) to check whether the data is possibly filled out by an automated program instead of a human. We retain these data via our subprocessor forever because they are used for anti-spam mitigation.
 
 ### Cookies and Do Not Track
 


### PR DESCRIPTION
We missed including this subprocessor in our lists earlier. Our login process across applications currently uses Google reCAPTCHA as a means to mitigate mass login attacks and other bot activiity. We intend to switch from reCAPTCHA to hCaptcha (which we currently use for HEY) for all other apps but in the meantime, wanted to get our documentation updated.