### PR TITLE
Weave in stronger values language, and separate out abuse@ and report@

### DIFF
--- a/abuse/how-we-handle/index.md
+++ b/abuse/how-we-handle/index.md
@@ -5,7 +5,7 @@ description: Guiding principles and process for investigating abuse reports
 
 # How we handle abusive usage
 
-*Last updated: April 13, 2020*
+*Last updated: January 19, 2021*
 
 We build our products* to give teams a better way to work. We are proud of that purpose and trust that our customers use our products for appropriate endeavors.
 
@@ -57,11 +57,15 @@ We strive to balance privacy and safety for all those involved:
 - As we review the evidence, we look for indications of existing negative impact. We also assess the severity of any potential negative impact, regardless of intent. When relevant, we look for and follow available guidelines from expert institutions.
 - If we cannot come to a fair assessment from the information available, we may decide to access a customer account without notice. We do not make this decision lightly. Customer privacy is a big deal to us and we only pursue this course of action if the evidence we have already is very concerning, but not definitive.
 
+While some violations are flatly obvious, others are subjective, nuanced, and difficult to adjudicate. We give each case adequate time and attention, commensurate with the violation, criticality, and severity of the charge.
+
 ### What happens if someone really broke the rules?
 
 We will terminate an account without advance notice if there is evidence it is being used for a restricted purpose that has, is, or will cause severe harm. If applicable, we will also report the incident to the appropriate authorities.
 
 For other cases, we’ll take a case-by-case approach to clear things up.
+
+Further, as a small, privately owned independent business that puts our values and conscience ahead of growth at all costs, we reserve the right to deny service to anyone we ultimately feel uncomfortable doing business with.
 
 ### Can you appeal a decision?
 

--- a/abuse/how-we-handle/index.md
+++ b/abuse/how-we-handle/index.md
@@ -15,7 +15,7 @@ Sometimes, though, we discover potential abusive usage as detailed in our [Use R
 
 ### Human oversight
 
-Who’s “we”, you ask? It’s us: folks from the Basecamp team. We have an internal committee who review all potential abuse cases. This committee includes our executives, David and Jason, and representatives from multiple departments across the company. On rare occasions for particularly sensitive situations or if legally required, we may also seek counsel from external experts.
+Who’s “we”, you ask? It’s us: folks from the Basecamp team. Our internal abuse oversight committee includes our executives, David and Jason, and representatives from multiple departments across the company. On rare occasions for particularly sensitive situations or if legally required, we may also seek counsel from external experts.
 
 ### Balanced responsibilities
 

--- a/abuse/index.md
+++ b/abuse/index.md
@@ -5,29 +5,31 @@ description: It is not okay to use Basecamp products for these restricted purpos
 
 # Use Restrictions
 
-*Last updated: June 24, 2020*
+*Last updated: January 19, 2021*
 
-Hundreds of thousands of teams use Basecamp products*. We are proud to give them a better way to work. We also recognize that technology is an amplifier: it can enable the helpful and the harmful. That’s why we’ve established this policy. If you have an account with any of our products, you can’t use them for any of the restricted purposes listed below. If we find out you are, [we will take action](how-we-handle/index.md).
+Hundreds of thousands of teams use Basecamp products*. We are proud to give them a better way to work. We also recognize that however good the maker’s intentions, technology can amplify the ability to cause great harm. That’s why we’ve established this policy. We feel an ethical obligation to counter such harm: both in terms of dealing with instances where Basecamp is used (and abused) to further such harm, and to state unequivocally that Basecamp is not a safe haven for people who wish to commit such harm. If you have an account with any of our products, you can’t use them for any of the restricted purposes listed below. If we find out you are, [we will take action](how-we-handle/index.md).
 
 ## Restricted purposes
 
+* **Violence, or threats thereof**: If an activity qualifies as violent crime in the United States or where you live, you may not use Basecamp products to plan, perpetrate, or threaten that activity.
 * **Child exploitation, sexualization, or abuse**: We don’t tolerate any activities that create, disseminate, or otherwise cause child abuse. Keep away and stop. Just stop.
 * **Doxing**: If you are using Basecamp products to share other peoples’ private personal information for the purposes of harassment, we don’t want anything to do with you.
-* **Infringing on intellectual property**: You can’t use Basecamp products to make or disseminate work that uses the intellectual property of others beyond the bounds of [fair use](https://www.copyright.gov/fair-use/more-info.html).
 * **Malware or spyware**: Code for good, not evil. If you are using our products to make or distribute anything that qualifies as malware or spyware — including remote user surveillance — begone.
 * **Phishing or otherwise attempting fraud**: It is not okay to lie about who you are or who you affiliate with to steal from, extort, or otherwise harm others.
 * **Spamming**: No one wants unsolicited commercial emails. We don’t tolerate folks (including their bots) using Basecamp products for spamming purposes. If your emails don’t pass muster with [CAN-SPAM](https://www.ftc.gov/tips-advice/business-center/guidance/can-spam-act-compliance-guide-business) or any other anti-spam law, it’s not allowed.
 * **Cybersquatting**: We don’t like username extortionists. If you purchase a Basecamp product account in someone else’s name and then try to sell that account to them, you are [cybersquatting](https://www.law.cornell.edu/uscode/text/15/1125). Cybersquatting accounts are subject to immediate cancelation.
-* **Violence, or threats thereof**: If an activity qualifies as violent crime in the United States or where you live, you may not use Basecamp products to plan, perpetrate, or threaten that activity.
+* **Infringing on intellectual property**: You can’t use Basecamp products to make or disseminate work that uses the intellectual property of others beyond the bounds of [fair use](https://www.copyright.gov/fair-use/more-info.html).
 
-We’ve outlined these restrictions to be clear about what we won’t stand for. That said, this list is by no means exhaustive. We will make changes over time.
+While our use restrictions are comprehensive, they can’t be exhaustive — it’s possible an offense could defy categorization, present for the first time, or illuminate a moral quandary we hadn’t yet considered. That said, we hope the overarching spirit is clear: Basecamp is not to be harnessed for harm, whether mental, physical, personal or civic. Different points of view — philosophical, religious, and political — are welcome, but ideologies like white nationalism, or hate-fueled movements anchored by oppression, violence, abuse, extermination, or domination of one group over another, will not be accepted here.
 
 ## How to report abuse
 
-See someone using a Basecamp product for one of the restricted purposes? Let us know by emailing [report@basecamp.com](mailto:report@basecamp.com) and [we will investigate](how-we-handle/index.md). If you’re not 100% sure, report it anyway.
+For cases of suspected malware, spyware, phishing, spamming, and cybersquatting, please alert us at [abuse@basecamp.com](mailto:abuse@basecamp.com).
+
+For all other cases, please let us know by emailing [report@basecamp.com](mailto:report@basecamp.com). If you’re not 100% sure if something rises to the level of our use restrictions policy, report it anyway.
 
 Please share as much as you are comfortable with about the account, the content or behavior you are reporting, and how you found it. Sending us a URL or screenshots is super helpful. If you need a secure file transfer, let us know and we will send you a link. We will not disclose your identity to anyone associated with the reported account. For copyright cases, we've outlined extra instructions on [how to notify us about infringement claims](../copyright/index.md).
 
-Someone on our team will respond within one business day to let you know we’ve begun investigating. We will also let you know the outcome of our investigation (unless you ask us not to or we are not allowed to under law).
+Someone on our team will respond within one business day to let you know we’ve begun investigating. We have published details on [how we investigate use restriction reports](how-we-handle/index.md). We will also let you know the outcome of our investigation (unless you ask us not to, or we are not allowed to under law).
 
 **This policy and process applies to any product created and owned by Basecamp, LLC. That includes Basecamp (any version), HEY, Highrise, Campfire, Backpack, Writeboard, and Ta-da List.*


### PR DESCRIPTION
On January 18, 2021, Jason and David reiterated our Use Restrictions policy on SvN: https://m.signalvnoise.com/reiterating-our-use-restrictions-policy/

This PR pulls in the some of the clearer language into our policy. It also separates out what cases should be sent to abuse@basecamp.com, which our Security team reviews, and which should go to report@basecamp.com, which our internal abuse oversight committee reviews.