### PR TITLE
redux at clarifying what happens with addresses upon HEY refunds

### DIFF
--- a/refund/hey/index.md
+++ b/refund/hey/index.md
@@ -16,7 +16,7 @@ Here are examples of refunds for HEY for You we’d grant:
 
 We’ll also consider giving credits for future cycles if something goes wrong on our side. For example, if we had extended downtime (multiple hours in a day, or multiple days in a month) or you emailed customer service and it took multiple days to get back to you, we’ll issue a partial credit to your account.
 
-If you cancel and request a refund within the first year, your @hey.com email address will be recycled after 90 days and made available to someone else.
+If you cancel and request a refund within the first year, your @hey.com email address will be recycled 30 days after account cancellation and made available to someone else. That's true for full refunds and prorated refunds, but doesn't apply for valid consumption tax refunds.
 
 ## HEY for Work
 HEY for Work subscriptions are paid on a monthly basis for each user (manager, co-worker) within an account. But we know that change happens, folks join or move on, and sometimes cleaning up email addresses that may no longer be needed might accidentally slip through the cracks.


### PR DESCRIPTION
our last update was confusing! sorry about that.

Side note: we know that the current process of not default keeping services available until the end of the paid term for HEY for You isn't right. It was a conscious compromise to ship, stay compliant with GDPR for those who wanted all data gone, and cut with the grain of an existing billing system. It's on us to change our set-up so that you have the choice between instant and end-of-billing. When we get that shipped, we'll be happily updating our refund policy again!