### PR TITLE
Replace Google's reCAPTCHA with hCaptcha

### DIFF
--- a/privacy/backpack-subprocessors/index.md
+++ b/privacy/backpack-subprocessors/index.md
@@ -12,7 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
-* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
+* [hCaptcha](https://hcaptcha.com/privacy). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [TaxJar](https://support.taxjar.com/article/526-taxjar-security-and-privacy-questions). Sales tax calculation.
 * [Twilio](https://www.twilio.com/gdpr). Text messaging service.

--- a/privacy/basecamp-subprocessors/index.md
+++ b/privacy/basecamp-subprocessors/index.md
@@ -13,7 +13,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Customer.io](https://customer.io/gdpr.html). Transactional email service.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
-* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
+* [hCaptcha](https://hcaptcha.com/privacy). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Mailchimp](https://mailchimp.com/gdpr/). Transactional email service.
 * [Sentry](https://blog.sentry.io/2018/03/14/gdpr-sentry-and-you). Error reporting software.

--- a/privacy/campfire-subprocessors/index.md
+++ b/privacy/campfire-subprocessors/index.md
@@ -12,7 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
-* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
+* [hCaptcha](https://hcaptcha.com/privacy). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [TaxJar](https://support.taxjar.com/article/526-taxjar-security-and-privacy-questions). Sales tax calculation.
 * [Twilio](https://www.twilio.com/gdpr). Text messaging service.

--- a/privacy/highrise-subprocessors/index.md
+++ b/privacy/highrise-subprocessors/index.md
@@ -12,7 +12,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
-* [Google reCAPTCHA](https://developers.google.com/recaptcha/). Anti-bot protection.
+* [hCaptcha](https://hcaptcha.com/privacy). Anti-bot protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.
 * [Heroku](https://devcenter.heroku.com/articles/gdpr). Cloud services provider.
 * [Mailgun](https://www.mailgun.com/gdpr/). Email service provider.

--- a/privacy/regulations/index.md
+++ b/privacy/regulations/index.md
@@ -5,7 +5,7 @@ description: Privacy laws are in a lot of flux. Here’s info you should know.
 
 # Privacy Regulations Reference
 
-*Last updated: December 4, 2020*
+*Last updated: July 12, 2021*
 
 The data privacy regulatory landscape is undergoing a lot of change. You probably have heard about the EU General Data Protection Regulation (GDPR) that went into effect on May 25, 2018. There are also other regulations in effect or in the works around the world. We’ve written up this reference document to put helpful information regarding our products and privacy regulations in one place. Please also view our full [Privacy policy](../index.md).
 


### PR DESCRIPTION
We've finally stopped using Google's reCAPTCHA, replacing it with hCaptcha. This removes it from all subprocessors' lists. 