### PR TITLE
Add Datadog to Basecamp and HEY data subprocessor lists

### DIFF
--- a/privacy/basecamp-subprocessors/index.md
+++ b/privacy/basecamp-subprocessors/index.md
@@ -11,6 +11,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
+* [Datadog](https://www.datadoghq.com/legal/privacy/). Infrastructure and application monitoring.
 * [Customer.io](https://customer.io/gdpr.html). Transactional email service.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
 * [hCaptcha](https://hcaptcha.com/privacy). Anti-bot protection.

--- a/privacy/hey-subprocessors/index.md
+++ b/privacy/hey-subprocessors/index.md
@@ -11,6 +11,7 @@ The following is a list of personal data subprocessors we use. These subprocesso
 
 * [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/). Cloud services provider.
 * [Braintree](https://www.braintreepayments.com/legal/payment-services-agreement-us). Payment processing services.
+* [Datadog](https://www.datadoghq.com/legal/privacy/). Infrastructure and application monitoring.
 * [Google Cloud Platform](https://cloud.google.com/security/gdpr/resource-center/). Cloud services provider.
 * [hCaptcha](https://hcaptcha.com/privacy). Anti-bot and spam protection.
 * [Help Scout](https://www.helpscout.net/company/legal/gdpr/). Help desk software.


### PR DESCRIPTION
Adds [Datadog](https://datadog.com/) to the list of data subprocessors for HEY and Basecamp.

See https://3.basecamp.com/2914079/buckets/27032456/todos/4930880329